### PR TITLE
Version 23.02.3: keep string in input even if not found in choices

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DataTools
 Type: Package
 Title: Data Tools for Shiny Apps
-Version: 23.02.2
+Version: 23.02.3
 Authors@R: c(
             person("Antonia", "Runge", email = "antonia.runge@inwt-statistics.de", role = c("cre", "aut"))
             )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,14 @@
 # DataTools
 
+## Version 23.02.3
+
+### Updates
+- import of Pandora dataset: keep string in input even if not found in choices (#19, PR #21)
+
 ## Version 23.02.2
 
 ### Updates
-- import of Pandora dataset: empty input as default input
+- import of Pandora dataset: empty input as default input (#19)
 
 ### Bug fixes
 - disable _"Accept Merged"_ / _"Accept Query"_ buttons if merge / query failed

--- a/R/02-importData.R
+++ b/R/02-importData.R
@@ -80,7 +80,7 @@ importDataServer <- function(id,
 
                    titles <-
                      unlist(lapply(ckanFiles(), `[[`, "title"))
-                   updateSelectInput(
+                   updateSelectizeInput(
                      session,
                      "ckanRecord",
                      choices = c("Select Pandora dataset ..." = "", titles),
@@ -106,6 +106,15 @@ importDataServer <- function(id,
                      shinyjs::hide(ns("acceptQuery"), asis = TRUE)
                    }
                  })
+
+                 # important for custom options of selectizeInput of ckanRecord:
+                 # forces update after selection (even with 'Enter') and
+                 # removes 'onFocus' as well as this.clear(true)
+                 observe({
+                   req(input$ckanRecord)
+                   updateSelectizeInput(session, "ckanRecord", selected = input$ckanRecord)
+                 }) %>%
+                   bindEvent(input$ckanRecord)
 
                  ckanRecord <- reactive({
                    req(input$ckanRecord)
@@ -452,11 +461,19 @@ selectDataTab <- function(ns, defaultSource = "ckan") {
         conditionalPanel(
           condition = "input.source == 'ckan'",
           ns = ns,
-          selectInput(
+          selectizeInput(
             ns("ckanRecord"),
             "Pandora dataset",
             choices = c("No Pandora dataset available" = ""),
-            width = "100%"
+            width = "100%",
+            options = list(
+              onFocus = I(
+                "function() {currentVal = this.getValue(); this.clear(true); }"
+              ),
+              onBlur = I(
+                "function() {if(this.getValue() == '') {this.setValue(currentVal, true)}}"
+              )
+            )
           ),
           selectizeInput(
             ns("ckanResource"),


### PR DESCRIPTION
## Version 23.02.3

### Updates
- import of Pandora dataset: keep string in input even if not found in choices (#19, PR #21)