### PR TITLE
display and return version of import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DataTools
 Type: Package
 Title: Data Tools for Shiny Apps
-Version: 24.08.2
+Version: 24.09.0
 Authors@R: c(
             person("Antonia", "Runge", email = "antonia.runge@inwt-statistics.de", role = c("cre", "aut"))
             )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# DataTools 24.09.0
+
+## Updates
+- when importing models:
+  - additionally to the display of warning and error messages, a new message
+  displays the version number under which a model was saved
+  - the version is now also part of the returned import object
+
 # DataTools 24.08.2
 
 ## Updates

--- a/R/02-importModule-configureFile.R
+++ b/R/02-importModule-configureFile.R
@@ -108,6 +108,7 @@ importMessageUI <- function(id) {
 
   div(
     style = "height: 9em",
+    div(class = "text-primary", uiOutput(ns("version"))),
     div(class = "text-warning", uiOutput(ns("warning"))),
     div(class = "text-danger", uiOutput(ns("error"))),
     div(class = "text-success", uiOutput(ns("success")))
@@ -123,6 +124,9 @@ importMessageUI <- function(id) {
 importMessageServer <- function(id, values) {
   moduleServer(id, function(input, output, session) {
     observe({
+      output$version <- renderUI(tagList(lapply(
+            unlist(values$version, use.names = FALSE), tags$p
+          )))
       output$warning <-
         renderUI(tagList(lapply(
           unlist(values$warnings, use.names = FALSE), tags$p

--- a/R/03-loadImport.R
+++ b/R/03-loadImport.R
@@ -19,6 +19,7 @@ resetValues <- function(values, includeData = TRUE) {
   values$errors <- list()
   values$fileName <- ""
   values$fileImportSuccess <- NULL
+  values$version <- NULL
   values$dataImport <- NULL
   values$preview <- NULL
 

--- a/R/03-loadModel.R
+++ b/R/03-loadModel.R
@@ -36,13 +36,18 @@ loadModelWrapper <- function(values,
     shinyTryCatch(errorTitle = "Unzipping failed.")
 
   # forward messages
+  values$version <-
+    ifelse(is.null(res$uploadedVersion),
+           "",
+           sprintf("Importing from: '%s'", res$uploadedVersion))
   values$fileImportSuccess <- res$message[res$messageType == "success"]
   values$warnings <- list(load = res$message[res$messageType == "warning"])
   values$errors <- list(load = res$message[res$messageType == "error"])
 
   if (!is.null(res)) {
     # select import values
-    values$dataImport <- res[c("data", "inputs", "model", "notes")]
+    objectsToReturn <- names(res)[names(res) %in% c("data", "inputs", "model", "notes", "uploadedVersion")]
+    values$dataImport <- res[objectsToReturn]
   }
 
   values$fileName <- filename


### PR DESCRIPTION
# DataTools 24.09.0

## Updates
- when importing models:
  - additionally to the display of warning and error messages, a new message
  displays the version number under which a model was saved
  - the version is now also part of the returned import object