### PR TITLE
DataTools 24.12.0: fix issue with missing filename

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DataTools
 Type: Package
 Title: Data Tools for Shiny Apps
-Version: 24.11.0
+Version: 24.12.0
 Authors@R: c(
             person("Antonia", "Runge", email = "antonia.runge@inwt-statistics.de", role = c("cre", "aut"))
             )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# DataTools 24.12.0
+
+## Bug fixes
+- fix issue with missing filename for file imports (#104)
+- prevent duplicated check of internet connection
+
 # DataTools 24.11.0
 
 ## New Features

--- a/R/02-importData-configureData.R
+++ b/R/02-importData-configureData.R
@@ -130,6 +130,7 @@ configureDataServer <- function(id,
                      values <- loadDataWrapper(
                        values = values,
                        filepath = dataSource[["file"]],
+                       filename = dataSource[["filename"]],
                        type = input[["fileType-type"]],
                        sep = input[["fileType-colSep"]],
                        dec = input[["fileType-decSep"]],

--- a/R/02-importData-linkToData.R
+++ b/R/02-importData-linkToData.R
@@ -256,6 +256,7 @@ loadFileFromLink <- function(values = reactiveValues(warnings = list(),
   values <- loadDataWrapper(
     values = values,
     filepath = dataSource[["file"]],
+    filename = dataSource[["filename"]],
     type = loadedFileInputs[["fileType-type"]],
     sep = loadedFileInputs[["fileType-colSep"]],
     dec = loadedFileInputs[["fileType-decSep"]],

--- a/R/02-importData.R
+++ b/R/02-importData.R
@@ -398,6 +398,22 @@ importDataServer <- function(id,
                    joinedData <-
                      mergeDataServer("dataMerger", mergeList = mergeList)
 
+                   # Following might not work since always when mergeList changes mergeDataServer
+                   # is called again which might overwrite existing joinedData
+                   # This needs more careful testing!
+                   # joinedData <- reactiveVal()
+                   # observe({
+                   #   req(length(mergeList()) > 0)
+                   #   logDebug("%s: setup  'dataMerger'", id)
+                   #   mergedData <-
+                   #     mergeDataServer("dataMerger", mergeList = mergeList)
+                   #
+                   #   observe({
+                   #     joinedData(mergedData())
+                   #   }) %>%
+                   #     bindEvent(mergedData())
+                   # })
+
                    ## disable button merge data ----
                    observe({
                      logDebug("Updating button acceptMerged")
@@ -457,8 +473,6 @@ importDataServer <- function(id,
                        )
                    }
 
-                   values <- values %>%
-                     resetValues()
                    values$data[[values$fileName]] <- res
                  })
 
@@ -469,8 +483,6 @@ importDataServer <- function(id,
                      removeOpenGptCon()
 
                      req(preparedData$data)
-                     values <- values %>%
-                       resetValues()
                      values$data[[values$fileName]] <-
                        preparedData$data %>%
                        formatForImport(
@@ -487,8 +499,7 @@ importDataServer <- function(id,
                      removeOpenGptCon()
                      customNames$withRownames <- FALSE
                      customNames$withColnames <- TRUE
-                     values <- values %>%
-                       resetValues()
+
                      values$data[[names(joinedData())[1]]] <-
                        joinedData()[[1]] %>%
                        formatForImport(
@@ -504,8 +515,7 @@ importDataServer <- function(id,
                      removeOpenGptCon()
                      customNames$withRownames <- FALSE
                      customNames$withColnames <- TRUE
-                     values <- values %>%
-                       resetValues()
+
                      values$data[[names(queriedData())[1]]] <-
                        queriedData()[[1]] %>%
                        formatForImport(
@@ -518,7 +528,15 @@ importDataServer <- function(id,
 
                  # return value for parent module: ----
                  # currently only the data is returned, not the path(s) to the source(s)
-                 reactive(values$data)
+                 returnData <- reactiveVal()
+                 observe({
+                   returnData(values$data)
+
+                   values <- values %>%
+                     resetValues()
+                 })
+
+                 return(returnData)
                })
 }
 

--- a/R/02-importModule.R
+++ b/R/02-importModule.R
@@ -184,14 +184,21 @@ importServer <- function(id,
       req(values$dataImport)
       res <- values$dataImport
 
-      values <- values %>% resetValues()
       values$data[[values$fileName]] <- res
     }) %>%
       bindEvent(input$accept)
 
     # return value for parent module: ----
     # currently only the data is returned, not the path(s) to the source(s)
-    reactive(values$data)
+    returnData <- reactiveVal()
+    observe({
+      returnData(values$data)
+
+      values <- values %>%
+        resetValues()
+    })
+
+    return(returnData)
   })
 }
 

--- a/R/02-remoteModels.R
+++ b/R/02-remoteModels.R
@@ -104,7 +104,8 @@ remoteModelsServer <- function(id,
                    if (reloadChoices() && githubRepo != "" && isInternet()) {
                      choices <-
                        getRemoteModelsFromGithub(githubRepo = githubRepo,
-                                                 folderOnGithub = folderOnGithub)
+                                                 folderOnGithub = folderOnGithub,
+                                                 isInternet = isInternet())
                    } else {
                      choices <- c()
                    }
@@ -252,10 +253,12 @@ checkLocalModelDir <-
 # @inheritParams remoteModelsServer
 # @param apiOut output of `getGithubContent()` if it was already loaded
 getRemoteModelsFromGithub <-
-  function(githubRepo, folderOnGithub = "/predefinedModels", apiOut = NULL) {
+  function(githubRepo, folderOnGithub = "/predefinedModels", apiOut = NULL, isInternet = FALSE) {
     if (is.null(apiOut)) {
       # if default value
-      apiOut <- getGithubContent(githubRepo = githubRepo, folderOnGithub = folderOnGithub)
+      apiOut <- getGithubContent(githubRepo = githubRepo,
+                                 folderOnGithub = folderOnGithub,
+                                 isInternet = isInternet)
     }
 
     # if nothing could be loaded
@@ -278,9 +281,7 @@ getRemoteModelsFromGithub <-
 # Get content of api call to github folder
 # @inheritParams remoteModelsServer
 getGithubContent <-
-  function(githubRepo, folderOnGithub = "/predefinedModels") {
-    isInternet <- has_internet()
-
+  function(githubRepo, folderOnGithub = "/predefinedModels", isInternet = FALSE) {
     if (isInternet) {
       tryGET(path = sprintf("api.github.com/repos/Pandora-IsoMemo/%s/contents/inst/app%s",
                             githubRepo,

--- a/R/03-loadData.R
+++ b/R/03-loadData.R
@@ -6,6 +6,7 @@
 #'
 #' @param values (list) list with import specifications
 #' @param filepath (character) url or path
+#' @param filename (character) file name
 #' @param type (character) file type input
 #' @param sep (character) column separator input
 #' @param dec (character) decimal separator input
@@ -14,6 +15,7 @@
 #' @param sheetId (numeric) sheet id
 loadDataWrapper <- function(values,
                             filepath,
+                            filename,
                             type,
                             sep,
                             dec,
@@ -63,8 +65,7 @@ loadDataWrapper <- function(values,
 
   }
 
-  values$fileName <- filepath %>%
-    basename()
+  values$fileName <- filename
 
   values
 }

--- a/man/loadDataWrapper.Rd
+++ b/man/loadDataWrapper.Rd
@@ -7,6 +7,7 @@
 loadDataWrapper(
   values,
   filepath,
+  filename,
   type,
   sep,
   dec,
@@ -19,6 +20,8 @@ loadDataWrapper(
 \item{values}{(list) list with import specifications}
 
 \item{filepath}{(character) url or path}
+
+\item{filename}{(character) file name}
 
 \item{type}{(character) file type input}
 

--- a/tests/testthat/test-importData.R
+++ b/tests/testthat/test-importData.R
@@ -26,7 +26,7 @@ test_that("Test module importData", {
 
                expect_true(all(names(values) %in%
                             c("data", "preview", "dataImport", "fileImportSuccess", "fileName",
-                              "errors", "warnings")))
+                              "errors", "warnings", "version")))
 
                # cannot test parent module of a submodule without adding some
                # undesired ignoreInit values in observers
@@ -87,7 +87,7 @@ test_that("Test module importData", {
 
                expect_true(all(names(values) %in%
                             c("data", "preview", "dataImport", "fileImportSuccess", "fileName",
-                              "errors", "warnings")))
+                              "errors", "warnings", "version")))
 
                # cannot test parent module of a submodule without adding some
                # undesired ignoreInit values in observers
@@ -175,7 +175,7 @@ test_that("Test module importData", {
 
                expect_true(all(names(values) %in%
                             c("data", "preview", "dataImport", "fileImportSuccess", "fileName",
-                              "errors", "warnings")))
+                              "errors", "warnings", "version")))
 
                # cannot test parent module of a submodule without adding some
                # undesired ignoreInit values in observers

--- a/tests/testthat/test-remoteModels.R
+++ b/tests/testthat/test-remoteModels.R
@@ -18,8 +18,11 @@ testthat::test_that("Test getRemoteModelsFromGithub", {
     # Arrange
     testApiContent <- getGithubContent(githubRepo = repo,
                                        folderOnGithub = getFolderOnGithub(mainFolder = mainFolder,
-                                                                          subFolder = NULL))
-    testRemoteModels <- getRemoteModelsFromGithub(githubRepo = repo, apiOut = testApiContent)
+                                                                          subFolder = NULL),
+                                       isInternet = TRUE)
+    testRemoteModels <- getRemoteModelsFromGithub(githubRepo = repo,
+                                                  apiOut = testApiContent,
+                                                  isInternet = TRUE)
 
     print(sprintf("test getRemoteModelsFromGithub() with repo: %s", repo))
     # Act
@@ -34,8 +37,11 @@ testthat::test_that("Test getRemoteModelsFromGithub", {
   for (subFol in ifelse(interactive(), subFolder, subFolder[sample(seq_along(subFolder), 1)])) {
     # Arrange
     testApiContent <- getGithubContent(githubRepo = repo,
-                                       folderOnGithub = getFolderOnGithub(mainFolder, subFol))
-    testRemoteModels <- getRemoteModelsFromGithub(githubRepo = repo, apiOut = testApiContent)
+                                       folderOnGithub = getFolderOnGithub(mainFolder, subFol),
+                                       isInternet = TRUE)
+    testRemoteModels <- getRemoteModelsFromGithub(githubRepo = repo,
+                                                  apiOut = testApiContent,
+                                                  isInternet = TRUE)
     expRemoteModels <- sprintf("testModel_MpiIsoApp_%s.zip", subFol)
     if (subFol == "OperatoR") {
       # "testMap" not "testModel"


### PR DESCRIPTION
# DataTools 24.12.0

## Bug fixes
- fix issue with missing filename for file imports (#104)
- prevent duplicated check of internet connection