### PR TITLE
DataTools 25.03.3: update buildignore, ReadMe and helptext

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,6 @@
 ^docs$
 ^pkgdown$
 ^\.github$
+^inst/app/predefinedModels/
+^inst/app/exampleZip/
+^inst/app/dataQueries/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DataTools
 Type: Package
 Title: Data Tools for Shiny Apps
-Version: 25.03.2.1
+Version: 25.03.3
 Authors@R: c(
             person("Antonia", "Runge", email = "antonia.runge@inwt-statistics.de", role = c("cre", "aut"))
             )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# DataTools 25.03.3
+
+## Updates
+- reduce package size by including test files into the `.Rbuildignore`
+- _importModule_: update help text if remote files are not available
+
 # DataTools 25.03.2
 
 ## Updates

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # DataTools Package
 
-### Contains :
+### Contains:
 
 - functions and modules that can be applied across the Isomemo Apps, and
 - an app to test the modules.
 
-### Release notes :
+### Documenation
+- https://pandora-isomemo.github.io/data-tools/
+
+### Release notes:
 - see `NEWS.md`
 
 
@@ -13,7 +16,7 @@
 
 Access to uploads from file, url, and the Pandora Platform. Optionally, merge data before the import via UI or SQL.
 
-UI function :
+UI function:
 
 ```R
 DataTools::importDataUI(id, label = "Import Data")


### PR DESCRIPTION
# DataTools 25.03.3

## Updates
- reduce package size by including test files into the `.Rbuildignore` (https://github.com/Pandora-IsoMemo/drat/issues/46)
- _importModule_: update help text if remote files are not available