### PR TITLE
DataTools 26.02.0: add logging and fix return value for zip imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,8 @@
 Package: DataTools
 Type: Package
 Title: Data Tools for Shiny Apps
-Version: 26.01.3
+Version: 26.02.0
+Date: 2026-02-13
 Authors@R: c(
             person("Antonia", "Runge", email = "antonia.runge@inwt-statistics.de", role = c("cre", "aut"))
             )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# DataTools 26.02.0
+
+## Updates
+- Improved observability and import handling by adding debug logging to zip/model imports and extending ACCEPT validation to support multiple return types (model/zip/list).
+
+## Bug Fixes
+- Fixed an issue where the ACCEPT button did not properly validate imported zips or lists, resulting in those objects not being imported.
+
 # DataTools 26.01.3
 
 ## Updates

--- a/R/02-importData.R
+++ b/R/02-importData.R
@@ -390,7 +390,7 @@ importDataServer <- function(id,
                  ## ACCEPT data ----
                  returnData <- reactiveVal(list())
                  observeEvent(input$accept, {
-                   logDebug("%s: Pressed input$accept", id)
+                   logDebug("%s: Pressed input$accept to import data", id)
                    removeModal()
 
                    req(values$dataImport, isTRUE(nrow(values$dataImport) > 0))

--- a/R/02-importModule.R
+++ b/R/02-importModule.R
@@ -193,7 +193,7 @@ importServer <- function(id,
         (is.character(values$dataImport)) &&
         (length(values$dataImport) == 1)
       is_list_import <- (importType == "list") &&
-        (is.list(values$dataImport)) &&
+        (is.list(values$dataImport) || is.raw(values$dataImport)) &&
         (length(values$dataImport) > 0)
 
       req(values$dataImport, isTRUE(is_model_import || is_zip_import || is_list_import))

--- a/R/02-importModule.R
+++ b/R/02-importModule.R
@@ -185,10 +185,19 @@ importServer <- function(id,
     ## ACCEPT button ----
     returnData <- reactiveVal()
     observe({
-      logDebug("%s: Entering observe 'input$accept'", id)
+      logDebug("%s: Pressed input$accept to import object", id)
       removeModal()
 
-      req(values$dataImport, isTRUE("inputs" %in% names(values$dataImport)))
+      is_model_import <- (importType == "model") && ("inputs" %in% names(values$dataImport))
+      is_zip_import <- (importType == "zip") &&
+        (is.character(values$dataImport)) &&
+        (length(values$dataImport) == 1)
+      is_list_import <- (importType == "list") &&
+        (is.list(values$dataImport)) &&
+        (length(values$dataImport) > 0)
+
+      req(values$dataImport, isTRUE(is_model_import || is_zip_import || is_list_import))
+      logDebug("%s: Import successful. Returning object of type %s", id, importType)
       res <- setNames(object = list(values$dataImport), nm = values$fileName)
       returnData(res)
 

--- a/R/03-loadModel.R
+++ b/R/03-loadModel.R
@@ -124,7 +124,6 @@ loadModel <-
       logDebug("Model import failed: %s", err_msg)
 
       stop(err_msg)
-      return(NULL)
     }
 
     if (!exists("modelImport") || length(modelImport) == 0 || !(
@@ -134,14 +133,12 @@ loadModel <-
       all(names(modelImport) %in% c("dataObj", "formulasObj", "inputObj", "model"))
     )
     ) {
-      err_msg <- sprintf(
-        "The file format may be invalid or deprecated. Expected a model object with names: %s.",
-        paste(c("data", "inputs", "values", "model", "version"), collapse = ", ")
+      err_msg <- paste(
+        "Model object not found in unzipped file.",
+        "The file format may be invalid or deprecated."
       )
-      err_msg <- paste("Model object not found in unzipped file.", err_msg)
-      logDebug(err_msg)
+      logDebug("%s", err_msg)
       stop(err_msg)
-      return(NULL)
     }
 
     # check if import was downloaded from the correct app
@@ -163,9 +160,8 @@ loadModel <-
                                  versionTxt, rPackageName),
                          sprintf(" Make sure to upload a model that was previously saved with %s.",
                                  rPackageName))
-      logDebug(errorMsg)
+      logDebug("%s", errorMsg)
       stop(errorMsg)
-      return(NULL)
     }
 
     # Currently, this check is relevant for the iso-app where sub-models are stored in sub-folders
@@ -187,9 +183,8 @@ loadModel <-
         subFolder,
         "."
       )
-      logDebug(err_msg)
+      logDebug("%s", err_msg)
       stop(err_msg)
-      return(NULL)
     }
 
     # Data check: which data objects are available (data, inputs and model?) ----

--- a/R/03-loadZip.R
+++ b/R/03-loadZip.R
@@ -78,7 +78,7 @@ loadZipWrapper <- function(values,
   }
 
   # Import successful: return zip path
-  logDebug("Zip import successful. Returning path to unzipped file: %s", res)
+  logDebug("Zip import successful. Returning the validated zip path: %s", res)
   values$dataImport <- res
   values$fileImportSuccess <- "Zip import successful"
   values

--- a/R/03-loadZip.R
+++ b/R/03-loadZip.R
@@ -42,6 +42,7 @@ loadZipWrapper <- function(values,
    values$fileName <- filename
 
   if (is.null(imp)) {
+    logDebug("Zip import failed.")
     values$dataImport <- NULL
     return(values)
   }
@@ -51,6 +52,7 @@ loadZipWrapper <- function(values,
   all_rel <- names(zi$index$files)
 
   if (length(all_rel) == 0L) {
+    logDebug("No files found in zip file.")
     values$errors <- c(values$errors, list(check = "No files found in zip file"))
     values$dataImport <- NULL
     return(values)
@@ -66,6 +68,7 @@ loadZipWrapper <- function(values,
     )
 
     if (!isTRUE(chk$ok)) {
+      logDebug("Expected files not found in zip file.")
       values$errors <- c(values$errors, list(load = paste0(
         "Expected files not found: ", paste(chk$missing, collapse = ", ")
       )))
@@ -74,7 +77,8 @@ loadZipWrapper <- function(values,
     }
   }
 
-  # Import successful: store zip path as before
+  # Import successful: return zip path
+  logDebug("Zip import successful. Returning path to unzipped file: %s", res)
   values$dataImport <- res
   values$fileImportSuccess <- "Zip import successful"
   values


### PR DESCRIPTION
# DataTools 26.02.0

## Updates
- Improved observability and import handling by adding debug logging to zip/model imports and extending ACCEPT validation to support multiple return types (model/zip/list).

## Bug Fixes
- Fixed an issue where the ACCEPT button did not properly validate imported zips or lists, resulting in those objects not being imported.