### PR TITLE
DataTools 26.08.0: Bug/error catcing not working

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: DataTools
 Type: Package
 Title: Data Tools for Shiny Apps
-Version: 26.05.0
-Date: 2026-05-21
+Version: 26.08.0
+Date: 2026-08-04
 Authors@R: c(
             person("Antonia", "Runge", email = "antonia.runge@inwt-statistics.de", role = c("cre", "aut"))
             )

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM inwt/r-shiny:4.3.2
+FROM inwt/r-shiny:4.4.3
 
 RUN echo "options(repos = c(getOption('repos'), PANDORA = 'https://Pandora-IsoMemo.github.io/drat/'))" >> /usr/local/lib/R/etc/Rprofile.site
+
+RUN Rscript -e "remotes::install_github('r-lib/httr2@v1.2.3')" \
+    && Rscript -e "remotes::install_github('tidyverse/ellmer@v0.4.1')"
 
 ADD . .
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# DataTools 26.08.0
+
+## Bug Fixes
+- Fixed an issue where Pandora API connection failures were not caught correctly in the import source selector
+
 # DataTools 26.05.0
 
 ## Updates

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # DataTools 26.08.0
 
 ## Bug Fixes
-- Fixed an issue where Pandora API connection failures were not caught correctly in the import source selector
+- Fixed handling of Pandora/import failures by correcting progress-wrapper evaluation and error catching across import modules.
 
 # DataTools 26.05.0
 

--- a/R/01-DataProcessLink-class.R
+++ b/R/01-DataProcessLink-class.R
@@ -111,7 +111,7 @@ load_data_from_link.DataProcessLink <- function(object, ...) {
   values <- withProgress(
     value = 0.75,
     message = sprintf("Importing '%s' from link ...", data_source[["filename"]]),
-    {
+    expr = {
       loadDataWrapper(
         values = args$values,
         filepath = data_source[["file"]],

--- a/R/01-DataProcessLink-class.R
+++ b/R/01-DataProcessLink-class.R
@@ -108,19 +108,23 @@ load_data_from_link.DataProcessLink <- function(object, ...) {
     removeNamespacePattern(pattern = c("dataSelector"))
 
   # load data
-  values <- loadDataWrapper(
-    values = args$values,
-    filepath = data_source[["file"]],
-    filename = data_source[["filename"]],
-    type = file_inputs[["fileType-type"]],
-    sep = file_inputs[["fileType-colSep"]],
-    dec = file_inputs[["fileType-decSep"]],
-    sheetId = as.numeric(file_inputs[["fileType-sheet"]]),
-    withRownames = args$customNames$withRownames,
-    withColnames = args$customNames$withColnames
-  ) %>%
-    withProgress(value = 0.75,
-                 message = sprintf("Importing '%s' from link ...", data_source[["filename"]]))
+  values <- withProgress(
+    value = 0.75,
+    message = sprintf("Importing '%s' from link ...", data_source[["filename"]]),
+    {
+      loadDataWrapper(
+        values = args$values,
+        filepath = data_source[["file"]],
+        filename = data_source[["filename"]],
+        type = file_inputs[["fileType-type"]],
+        sep = file_inputs[["fileType-colSep"]],
+        dec = file_inputs[["fileType-decSep"]],
+        sheetId = as.numeric(file_inputs[["fileType-sheet"]]),
+        withRownames = args$customNames$withRownames,
+        withColnames = args$customNames$withColnames
+      )
+    }
+  )
 
   values
 }

--- a/R/02-importData-configureData.R
+++ b/R/02-importData-configureData.R
@@ -116,19 +116,23 @@ configureDataServer <- function(id,
                      req(dataSource$type != "dataLink")
                      logDebug("Updating values$dataImport")
                      # importType is now always "data" here
-                     values <- loadDataWrapper(
-                       values = values,
-                       filepath = dataSource[["file"]],
-                       filename = dataSource[["filename"]],
-                       type = input[["fileType-type"]],
-                       sep = input[["fileType-colSep"]],
-                       dec = input[["fileType-decSep"]],
-                       sheetId = as.numeric(input[["fileType-sheet"]]),
-                       withRownames = customNames$withRownames,
-                       withColnames = customNames$withColnames
-                     ) %>%
-                       withProgress(value = 0.75,
-                                    message = sprintf("Importing '%s' ...", dataSource[["filename"]]))
+                     values <- withProgress(
+                       value = 0.75,
+                       message = sprintf("Importing '%s' ...", dataSource[["filename"]]),
+                       {
+                         loadDataWrapper(
+                           values = values,
+                           filepath = dataSource[["file"]],
+                           filename = dataSource[["filename"]],
+                           type = input[["fileType-type"]],
+                           sep = input[["fileType-colSep"]],
+                           dec = input[["fileType-decSep"]],
+                           sheetId = as.numeric(input[["fileType-sheet"]]),
+                           withRownames = customNames$withRownames,
+                           withColnames = customNames$withColnames
+                         )
+                       }
+                     )
                    }) # end observe loadImport
 
                  importMessageServer("importMessage", values)

--- a/R/02-importData-configureData.R
+++ b/R/02-importData-configureData.R
@@ -116,23 +116,23 @@ configureDataServer <- function(id,
                      req(dataSource$type != "dataLink")
                      logDebug("Updating values$dataImport")
                      # importType is now always "data" here
-                     values <- withProgress(
-                       value = 0.75,
-                       message = sprintf("Importing '%s' ...", dataSource[["filename"]]),
-                       {
-                         loadDataWrapper(
-                           values = values,
-                           filepath = dataSource[["file"]],
-                           filename = dataSource[["filename"]],
-                           type = input[["fileType-type"]],
-                           sep = input[["fileType-colSep"]],
-                           dec = input[["fileType-decSep"]],
-                           sheetId = as.numeric(input[["fileType-sheet"]]),
-                           withRownames = customNames$withRownames,
-                           withColnames = customNames$withColnames
-                         )
-                       }
-                     )
+                      values <- withProgress(
+                        value = 0.75,
+                        message = sprintf("Importing '%s' ...", dataSource[["filename"]]),
+                        expr = {
+                          loadDataWrapper(
+                            values = values,
+                            filepath = dataSource[["file"]],
+                            filename = dataSource[["filename"]],
+                            type = input[["fileType-type"]],
+                            sep = input[["fileType-colSep"]],
+                            dec = input[["fileType-decSep"]],
+                            sheetId = as.numeric(input[["fileType-sheet"]]),
+                            withRownames = customNames$withRownames,
+                            withColnames = customNames$withColnames
+                          )
+                        }
+                      )
                    }) # end observe loadImport
 
                  importMessageServer("importMessage", values)

--- a/R/02-importData-selectSource.R
+++ b/R/02-importData-selectSource.R
@@ -149,13 +149,13 @@ selectSourceServer <- function(id,
                      options(timeout = 10)  # Set timeout to 10 seconds
 
                      on.exit(options(timeout = old_timeout))  # Restore old timeout when function ends
-                     shinyTryCatch(
-                       expr = withProgress(message = "Connecting to Pandora...", {
-                         callAPI(action = "group_list", all_fields = "true")
-                       }),
-                       errorTitle = "Pandora connection error",
-                       alertStyle = "shinyalert"
-                     )
+                      shinyTryCatch(
+                        expr = withProgress(message = "Connecting to Pandora...", expr = {
+                          callAPI(action = "group_list", all_fields = "true")
+                        }),
+                        errorTitle = "Pandora connection error",
+                        alertStyle = "shinyalert"
+                      )
                    })
                    } else {
                      res <- NULL

--- a/R/02-importData-selectSource.R
+++ b/R/02-importData-selectSource.R
@@ -149,9 +149,13 @@ selectSourceServer <- function(id,
                      options(timeout = 10)  # Set timeout to 10 seconds
 
                      on.exit(options(timeout = old_timeout))  # Restore old timeout when function ends
-                     callAPI(action = "group_list", all_fields = "true") %>%
-                       withProgress(message = "Connecting to Pandora...") %>%
-                       shinyTryCatch(errorTitle = "Pandora connection error", alertStyle = "shinyalert")
+                     shinyTryCatch(
+                       expr = withProgress(message = "Connecting to Pandora...", {
+                         callAPI(action = "group_list", all_fields = "true")
+                       }),
+                       errorTitle = "Pandora connection error",
+                       alertStyle = "shinyalert"
+                     )
                    })
                    } else {
                      res <- NULL
@@ -179,10 +183,14 @@ selectSourceServer <- function(id,
                      options(timeout = 10)  # Set timeout to 10 seconds
 
                      on.exit(options(timeout = old_timeout))  # Restore old timeout when function ends
-                     callAPI(action = "current_package_list_with_resources",
-                             limit = 1000) %>%
-                       withProgress(message = "Loading Pandora packages...") %>%
-                       shinyTryCatch(errorTitle = "Pandora connection error", alertStyle = "shinyalert")
+                     shinyTryCatch(
+                       expr = withProgress(message = "Loading Pandora packages...", {
+                         callAPI(action = "current_package_list_with_resources",
+                                 limit = 1000)
+                       }),
+                       errorTitle = "Pandora connection error",
+                       alertStyle = "shinyalert"
+                     )
                    })
 
                    if (length(res) > 0) {

--- a/R/02-importModule-configureFile.R
+++ b/R/02-importModule-configureFile.R
@@ -77,7 +77,7 @@ configureFileServer <- function(id,
       values <- withProgress(
         value = 0.75,
         message = sprintf("Importing '%s' ...", dataSource[["filename"]]),
-        {
+        expr = {
           loadImport(
             importType = importType,
             params = list(

--- a/R/02-importModule-configureFile.R
+++ b/R/02-importModule-configureFile.R
@@ -72,23 +72,27 @@ configureFileServer <- function(id,
       req(dataSource$type != "dataLink")
       logDebug("Updating values$dataImport")
 
-      values <- values %>% resetValues()
+      values <- resetValues(values)
 
-      values <- loadImport(
-        importType = importType,
-        params = list(
-          values = values,
-          filepath = dataSource[["file"]],
-          filename = dataSource[["filename"]],
-          subFolder = subFolder,
-          rPackageName = rPackageName,
-          onlySettings = onlySettings,
-          fileExtension = fileExtension,
-          expectedFileInZip = expectedFileInZip
-        )
-      ) %>%
-        withProgress(value = 0.75,
-                     message = sprintf("Importing '%s' ...", dataSource[["filename"]]))
+      values <- withProgress(
+        value = 0.75,
+        message = sprintf("Importing '%s' ...", dataSource[["filename"]]),
+        {
+          loadImport(
+            importType = importType,
+            params = list(
+              values = values,
+              filepath = dataSource[["file"]],
+              filename = dataSource[["filename"]],
+              subFolder = subFolder,
+              rPackageName = rPackageName,
+              onlySettings = onlySettings,
+              fileExtension = fileExtension,
+              expectedFileInZip = expectedFileInZip
+            )
+          )
+        }
+      )
     }) %>%
       bindEvent(list(dataSource[["file"]], input[["fileType-type"]]), ignoreInit = TRUE)
 

--- a/tests/testthat/helper-pandora.R
+++ b/tests/testthat/helper-pandora.R
@@ -1,0 +1,31 @@
+pandora_api_available <- local({
+  checked <- FALSE
+  available <- FALSE
+
+  function(timeout = 10) {
+    if (checked) return(available)
+
+    old_timeout <- getOption("timeout")
+    on.exit(options(timeout = old_timeout), add = TRUE)
+    options(timeout = timeout)
+
+    available <<- tryCatch({
+      res <- Pandora::callAPI(action = "group_list", all_fields = "true")
+      !is.null(res) && length(res) > 0
+    }, error = function(e) {
+      FALSE
+    }, warning = function(w) {
+      FALSE
+    })
+
+    checked <<- TRUE
+    available
+  }
+})
+
+skip_if_no_pandora_api <- function() {
+  testthat::skip_if_not(
+    pandora_api_available(),
+    "Pandora API is not accessible; skipping Pandora-dependent tests."
+  )
+}

--- a/tests/testthat/test-ckan.R
+++ b/tests/testthat/test-ckan.R
@@ -1,3 +1,5 @@
+skip_if_no_pandora_api()
+
 test_that("Test getCKANRecordChoices()", {
   expect_true(
     all(c(

--- a/tests/testthat/test-importData-selectData.R
+++ b/tests/testthat/test-importData-selectData.R
@@ -1,3 +1,5 @@
+skip_if_no_pandora_api()
+
 test_that("Test module selectSourceServer", {
   testServer(selectSourceServer,
              args = list(importType = "data",

--- a/tests/testthat/test-importData.R
+++ b/tests/testthat/test-importData.R
@@ -1,3 +1,5 @@
+skip_if_no_pandora_api()
+
 test_that("Test module importData", {
   testServer(importDataServer,
              {


### PR DESCRIPTION
# DataTools 26.08.0

## Bug Fixes
- Fixed handling of Pandora/import failures by correcting progress-wrapper evaluation and error catching across import modules.